### PR TITLE
NEW - Add support for python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ services:
   - docker
   
 before_install:
-  - docker build -t kpndigital/tox:py27_py35 .
+  - docker build -t kpndigital/tox:py27_py35_py36 .
 
 script:
-  - docker run --rm kpndigital/tox:py27_py35 python2.7 --version
-  - docker run --rm kpndigital/tox:py27_py35 python3.5 --version
+  - docker run --rm kpndigital/tox:py27_py35_py36 python2.7 --version
+  - docker run --rm kpndigital/tox:py27_py35_py36 python3.5 --version
+  - docker run --rm kpndigital/tox:py27_py35_py36 python3.6 --version
   
-  - docker run --rm kpndigital/tox:py27_py35 bash -c "virtualenv /tmp && test -f /tmp/bin/pip"
-  - docker run --rm kpndigital/tox:py27_py35 bash -c "virtualenv -ppython3.5 /tmp && test -f /tmp/bin/pip"
-  - docker run --rm kpndigital/tox:py27_py35 bash -c "docker-compose --version"
+  - docker run --rm kpndigital/tox:py27_py35_py36 bash -c "virtualenv /tmp && test -f /tmp/bin/pip"
+  - docker run --rm kpndigital/tox:py27_py35_py36 bash -c "virtualenv -ppython3.5 /tmp && test -f /tmp/bin/pip"
+  - docker run --rm kpndigital/tox:py27_py35_py36 bash -c "python3.6 -m venv /tmp && test -f /tmp/bin/pip"
+  - docker run --rm kpndigital/tox:py27_py35_py36 bash -c "docker-compose --version"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM ubuntu:16.04 
-ENV pythonVersions='python2.7 python3.5'
+FROM ubuntu:16.10
+ENV python2Versions='python2.7'
+ENV python3Versions='python3.5 python3.6'
+ENV pythonVersions="$python2Versions $python3Versions"
 
 RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends $pythonVersions \
+    && apt-get install -y $(for py3ver in $python3Versions; do echo $py3ver-venv; done) \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update \


### PR DESCRIPTION
Had to update from Ubuntu 16.04 to 16.10 because
16.04 does not have python3.6 without backports
or PPAs.

Higher than 16.10 (e.g. 17.04) does not
work currently since docker does not have a
docker-ce package available yet.